### PR TITLE
Initial Kali image for Google Compute Engine support

### DIFF
--- a/gce
+++ b/gce
@@ -7,8 +7,9 @@ gce_project=
 # Image details
 image_name_suffix=v$(date +%Y%m%d)
 build_date=$(date +%Y-%m-%d)
-volume_size='10'
-apt_mirrors='http://gce_debian_mirror.storage.googleapis.com/ http://http.debian.net/debian'
+volume_size='20'
+#apt_mirrors='http://gce_debian_mirror.storage.googleapis.com/ http://http.debian.net/debian'
+apt_mirrors='http://http.kali.org/kali'
 gce_kernel=projects/google/global/kernels/gce-v20130813
 
 # $description is set later if it has no value yet. This is

--- a/tasks/gce/25-install-gce-debs
+++ b/tasks/gce/25-install-gce-debs
@@ -5,3 +5,10 @@ DEBS="google-compute-daemon google-startup-scripts image-bundle gcutil"
 for deb in $DEBS; do
   chroot $imagedir apt-get install --force-yes -y ${deb}
 done
+
+# These are startup scripts that are network services.
+# This is normally disabled in Kali by default, so we need to manually enable.
+chroot $imagedir update-rc.d ssh enable
+chroot $imagedir update-rc.d google enable
+chroot $imagedir update-rc.d google-address-manager enable
+chroot $imagedir update-rc.d google-accounts-manager enable

--- a/tasks/gce/75-compress-image
+++ b/tasks/gce/75-compress-image
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Create the compressed image file
 
-tarball_name="$distribution-$lsb_release-$codename-$image_name_suffix.tar.gz"
+tarball_name="$distribution-$codename-$image_name_suffix.tar.gz"
 log "Creating $tarball_name."
 tar czSpf $workspace/$tarball_name -C $workspace disk.raw


### PR DESCRIPTION
Initial work to build an image for Google Compute Engine.  Builds an image successfully, you need to pass a URL to your Google Storage in order to upload the image during build (or you can upload it yourself after build) - finished image is about 333MB in size.
