### PR TITLE
Update kali-cloud-build for sana

### DIFF
--- a/kali-cloud-build
+++ b/kali-cloud-build
@@ -35,7 +35,7 @@ timezone='UTC'
 # Hardcoded params.
 # This script would explode if we had to take care of other distributions
 distribution='kali'
-codename='kali'
+codename='sana'
 
 # Filesystem and image info
 filesystem='ext4'

--- a/tasks/ec2/01-packages-ec2
+++ b/tasks/ec2/01-packages-ec2
@@ -2,7 +2,7 @@
 # Add some basic packages we are going to need
 
 # Apparently isc-dhcp-client doesn't work properly with ec2
-packages+=('dhcpcd')
+packages+=('dhcpcd5')
 
 # We use dhcpcd instead
 exclude_packages+=('isc-dhcp-client')

--- a/tasks/ec2/39-dhcpcd-conf
+++ b/tasks/ec2/39-dhcpcd-conf
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # let the DHCP client manage /etc/resolv.conf
-sed -i -e "s/^#*SET_DNS=.*/SET_DNS='yes'/" $imagedir/etc/default/dhcpcd
+sed -i -e "s/^#*SET_DNS=.*/SET_DNS='yes'/" $imagedir/etc/dhcpcd.conf


### PR DESCRIPTION
Update the build script to point to sana not kali.
dhcpcd is now called dhcpcd5
The configuration is moved to /etc/dhcpcd.conf