### PR TITLE
Bug fixes for kali sana AMI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The machine configuration this script creates has been thoroughly tested.
 <pre>
 $ cd ~
 $ sudo apt-get install git debootstrap
-$ sudo ln -sf /usr/share/debootstrap/scripts/{wheezy,kali}
+$ sudo ln -sf /usr/share/debootstrap/scripts/{wheezy,sana}
 $ git clone https://github.com/offensive-security/kali-cloud-build.git 
 $ cd kali-cloud-build
 $ sudo ./kali-cloud-build ec2 --secret-key xxxxxxxxxxxxx --access-key xxxxxxxxxxxxx

--- a/tasks/21-apt-sources
+++ b/tasks/21-apt-sources
@@ -11,6 +11,6 @@ EOF
 done
 
 cat >> $imagedir/etc/apt/sources.list <<EOF
-deb http://security.kali.org/kali-security kali/updates main contrib non-free
-deb-src http://security.kali.org/kali-security kali/updates main contrib non-free
+deb http://security.kali.org/kali-security sana/updates main contrib non-free
+deb-src http://security.kali.org/kali-security sana/updates main contrib non-free
 EOF


### PR DESCRIPTION
* Fixes an issue where the build script would check for /usr/share/debootstrap/scripts/sana when it was set to create a 'kali' directory.

* Also fixed the apt sources to be set for 'sana' instead of 'kali'